### PR TITLE
Minor fix for plugin

### DIFF
--- a/lua/snippets/nonextmark_inserter.lua
+++ b/lua/snippets/nonextmark_inserter.lua
@@ -7,7 +7,7 @@
 -- TODO(ashkan): bounds check to avoid going to markers which are from previous insertions or something like that?
 local format = string.format
 local api = vim.api
-local splitter = require 'splitter'
+local splitter = require 'snippets.splitter'
 local parser = require 'snippets.parser'
 local U = require 'snippets.common'
 


### PR DESCRIPTION
If `snippets.nvim` is installed as a plugin via vim packages, it doesn't work because the `splitter.lua` file isn't put into the packpath. You need to explicitly require it as `snippets.splitter`, just like the `parser` below it.