### PR TITLE
add expand_or_advance convenience function

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,13 @@ lua require'snippets'.use_suggested_mappings()
 " This variant will set up the mappings only for the *CURRENT* buffer.
 lua require'snippets'.use_suggested_mappings(true)
 
-" There is only one keybinding specified by the suggested keymappings, which is <C-k>
+" There is only one keybinding specified by the suggested keymappings, which is <C-k>.
 " This is exactly equivalent to
-inoremap <c-k> <cmd>lua return require'snippets'.expand_at_cursor() or require'snippets'.advance_snippet(1)<CR>
-" Which will either expand the current snippet at the word or try to jump to the next position for the snippet.
+inoremap <c-k> <cmd>lua return require'snippets'.expand_or_advance()<CR>
+" which will either expand the current snippet at the word
+" or try to jump to the next position for the snippet.
 
-lua <<EOF
+```lua
 require'snippets'.snippets = {
 	lua = {
 		["for"] = "for ${1:i}, ${2:v} in ipairs(${3:t}) do\n$0\nend";
@@ -67,7 +68,6 @@ union ${1:name} {
 		important = "IMPORTANT(ashkan): ";
   };
 }
-EOF
 ```
 
 By default no snippets are stored inside of `require'snippets'.snippets`.

--- a/lua/snippets.lua
+++ b/lua/snippets.lua
@@ -104,9 +104,13 @@ local function expand_at_cursor()
 	return false
 end
 
+local function expand_or_advance()
+		return expand_at_cursor() or advance_snippet(1)
+end
+
 local example_keymap = {
 	["i<c-k>"] = {
-		"<cmd>lua local s = require'snippets'; return s.expand_at_cursor() or s.advance_snippet(1)<CR>",
+		"<cmd>lua return require'snippets'.expand_or_advance()<CR>";
 		noremap = true;
 	}
 }
@@ -114,6 +118,7 @@ local example_keymap = {
 return setmetatable({
 	expand_at_cursor = expand_at_cursor;
 	advance_snippet = advance_snippet;
+	expand_or_advance = expand_or_advance;
 	mappings = example_keymap;
 	use_suggested_mappings = function(buffer_local)
 		for k, v in pairs(example_keymap) do


### PR DESCRIPTION
Adds an `expand_or_advance` shim around the `expand_at_cursor() or advance_snippet(1)` operation, exports it, and uses it for the example_keymap. 