### PR TITLE
Remove "leftover" mappings

### DIFF
--- a/lua/snippets/inserters/floaty.lua
+++ b/lua/snippets/inserters/floaty.lua
@@ -315,8 +315,8 @@ local function entrypoint(structure)
 
 	api.nvim_buf_set_keymap(input_buf, 'i', '<c-g>', '<Cmd>lua SNIPPETS_FLOATY_HANDLER(0)<cr>', { noremap = true; silent = true })
 	api.nvim_buf_set_keymap(input_buf, 'i', '<c-c>', '<Cmd>lua SNIPPETS_FLOATY_HANDLER(0)<cr>', { noremap = true; silent = true })
-	api.nvim_buf_set_keymap(input_buf, 'i', '<c-k>', '<Cmd>lua SNIPPETS_FLOATY_HANDLER(1)<cr>', { noremap = true; silent = true })
-	api.nvim_buf_set_keymap(input_buf, 'i', '<c-j>', '<Cmd>lua SNIPPETS_FLOATY_HANDLER(-1)<cr>', { noremap = true; silent = true })
+	-- api.nvim_buf_set_keymap(input_buf, 'i', '<c-k>', '<Cmd>lua SNIPPETS_FLOATY_HANDLER(1)<cr>', { noremap = true; silent = true })
+	-- api.nvim_buf_set_keymap(input_buf, 'i', '<c-j>', '<Cmd>lua SNIPPETS_FLOATY_HANDLER(-1)<cr>', { noremap = true; silent = true })
 
 	local R
 


### PR DESCRIPTION
Im configuring snippets.nvim as:

```
  vim.cmd [[ inoremap <silent><expr> <Return> pumvisible() ? "\<c-y>\<cr>" : "\<CR>" ]]
  vim.cmd [[ inoremap <silent><expr> <C-j> pumvisible() ? "\<C-n>" : "\<cmd>lua return require'snippets'.expand_or_advance()<CR>" ]]
  vim.cmd [[ inoremap <silent><expr> <C-k> pumvisible() ? "\<C-p>" : "\<cmd>lua return require'snippets'.advance_snippet(-1)<CR>" ]]
```

Which inverts the default mappings, that is `c-j` is used to expand or advance forward and `c-k` to advance backwards. That worked to expand the snippet, but once the float window was shown, the default behavior was still applied so `c-j` would go backwards and cancel the snippet expansion instead of advancing to second placeholder.
I'm commenting out the lines I think should be removed.

Thanks!